### PR TITLE
Added v0.1.2 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Akka.Remote and Akka.Cluster bootstrapping utilities for [Akka.NET](http://getak
 To learn more about a specific runtime environment, please see the following:
 
 * **[Bootstrapping Akka.NET for Docker](src/Akka.Bootstrap.Docker)**
+* **[Bootstrapping Akka.NET for Pivotal Cloud Foundry (PCF)](src/Akka.Bootstrap.PCF)**
 
 ## Building this solution
 To run the build script associated with this solution, execute the following:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 0.1.2 April 13 2018 ####
+* Completed: [Add flag to see if we're currently running in PCF environment](https://github.com/petabridge/akkadotnet-bootstrap/issues/9)
+
 #### 0.1.1 April 11 2018 ####
 Added support for `Akka.Bootstrap.PCF`.
 

--- a/src/Akka.Bootstrap.PCF/readme.md
+++ b/src/Akka.Bootstrap.PCF/readme.md
@@ -1,0 +1,9 @@
+# Akka.Bootstrap.PCF
+
+This project is designed to make it easier to automatically bootstrap Akka.Remote and Akka.Cluster nodes when running inside of [Pivotal's Cloud Foundry Platform (PCF)](https://pivotal.io/platform).
+
+At the moment, this project supports any runtimes compatible with the following:
+
+1. .NET Standard 1.6
+
+This project is a work in progress, as we have some blocking issues preventing it from being completed at the moment but we expect to resolve those soon. Stay tuned.

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <Copyright>Copyright © 2018 Petabridge®</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PackageReleaseNotes>Added support for `Akka.Bootstrap.PCF`.</PackageReleaseNotes>
+    <VersionPrefix>0.1.2</VersionPrefix>
+    <PackageReleaseNotes>Completed: [Add flag to see if we're currently running in PCF environment](https://github.com/petabridge/akkadotnet-bootstrap/issues/9)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/petabridge/akkadotnet-bootstrap</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/petabridge/akkadotnet-bootstrap/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 0.1.2 April 13 2018 ####
* Completed: [Add flag to see if we're currently running in PCF environment](https://github.com/petabridge/akkadotnet-bootstrap/issues/9)