### PR TITLE
v0.1.3 release notes; Akka.NET 1.3.6 upgrade; XML-DOC output

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.1.3 April 26 2018 ####
+* Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6)
+* Added XML-DOCs to NuGet package output.
+
 #### 0.1.2 April 13 2018 ####
 * Completed: [Add flag to see if we're currently running in PCF environment](https://github.com/petabridge/akkadotnet-bootstrap/issues/9)
 

--- a/src/Akka.Bootstrap.Docker/Akka.Bootstrap.Docker.csproj
+++ b/src/Akka.Bootstrap.Docker/Akka.Bootstrap.Docker.csproj
@@ -8,8 +8,13 @@
   </PropertyGroup>
 
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard1.6\Akka.Bootstrap.Docker.xml</DocumentationFile>
+  </PropertyGroup>
+
+
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.5" />
+    <PackageReference Include="Akka" Version="1.3.6" />
   </ItemGroup>
 
 </Project>

--- a/src/Akka.Bootstrap.PCF/Akka.Bootstrap.PCF.csproj
+++ b/src/Akka.Bootstrap.PCF/Akka.Bootstrap.PCF.csproj
@@ -4,8 +4,11 @@
     <TargetFramework>netstandard1.6</TargetFramework>
     <Description>Akka.Remote and Akka.Cluster bootstrapping utilities for Pivotal Cloud Foundry (PCF.)</Description>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard1.6\Akka.Bootstrap.PCF.xml</DocumentationFile>
+  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.5" />
+    <PackageReference Include="Akka" Version="1.3.6" />
   </ItemGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2018 Petabridge®</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.2</VersionPrefix>
-    <PackageReleaseNotes>Completed: [Add flag to see if we're currently running in PCF environment](https://github.com/petabridge/akkadotnet-bootstrap/issues/9)</PackageReleaseNotes>
+    <VersionPrefix>0.1.3</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6)
+Added XML-DOCs to NuGet package output.</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/petabridge/akkadotnet-bootstrap</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/petabridge/akkadotnet-bootstrap/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 0.1.3 April 26 2018 ####
* Upgraded to [Akka.NET v1.3.6](https://github.com/akkadotnet/akka.net/releases/tag/v1.3.6)
* Added XML-DOCs to NuGet package output.