### PR TITLE
added v0.3.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,3 @@
-#### 0.2.2 November 18 2019 ####
+#### 0.3.0 December 31 2019 ####
 * Updated all underlying dependencies to Akka.NET latest.
+* Added [support for automatically loading environment variables into HOCON via Akka.Bootstrap.Docker](https://github.com/petabridge/akkadotnet-bootstrap/issues/62).

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge®</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.2.2</VersionPrefix>
-    <PackageReleaseNotes>Updated all underlying dependencies to Akka.NET latest.</PackageReleaseNotes>
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <PackageReleaseNotes>Updated all underlying dependencies to Akka.NET latest.
+Added [support for automatically loading environment variables into HOCON via Akka.Bootstrap.Docker](https://github.com/petabridge/akkadotnet-bootstrap/issues/62).</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/petabridge/akkadotnet-bootstrap</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/petabridge/akkadotnet-bootstrap/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 0.3.0 December 31 2019 ####
* Updated all underlying dependencies to Akka.NET latest.
* Added [support for automatically loading environment variables into HOCON via Akka.Bootstrap.Docker](https://github.com/petabridge/akkadotnet-bootstrap/issues/62).