### PR TITLE
Log the actual seed nodes instead of the type name

### DIFF
--- a/src/Akka.Bootstrap.Docker/DockerBootstrap.cs
+++ b/src/Akka.Bootstrap.Docker/DockerBootstrap.cs
@@ -56,7 +56,7 @@ namespace Akka.Bootstrap.Docker
             // Diagnostic logging
             Console.WriteLine($"[Docker-Bootstrap] IP={finalConfig.GetString("akka.remote.dot-netty.tcp.public-hostname")}");
             Console.WriteLine($"[Docker-Bootstrap] PORT={finalConfig.GetString("akka.remote.dot-netty.tcp.port")}");
-            Console.WriteLine($"[Docker-Bootstrap] SEEDS={finalConfig.GetStringList("akka.cluster.seed-nodes")}");
+            Console.WriteLine($"[Docker-Bootstrap] SEEDS={string.Join(", ", finalConfig.GetStringList("akka.cluster.seed-nodes"))}");
 
             return finalConfig;
         }


### PR DESCRIPTION
Currently the log output is:

```
[Docker-Bootstrap] SEEDS=System.Collections.Generic.List`1[System.String]
```

with this change it will be:

```
[Docker-Bootstrap] SEEDS=akka.tcp://actors@seed1:4053, akka.tcp://actors@seed2:4053
```