### PR TITLE
modernized build system

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -15,6 +15,10 @@ jobs:
         clean: false  # whether to fetch clean each time
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core Runtime 3.1.10'
+        inputs:
+          version: '3.1.x'
       # Linux or macOS
       - task: Bash@3 
         displayName: Linux / OSX Build

--- a/build.fsx
+++ b/build.fsx
@@ -121,7 +121,7 @@ Target "RunTests" (fun _ ->
             info.WorkingDirectory <- (Directory.GetParent project).FullName
             info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
         
-        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result  
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result  
 
     projects |> Seq.iter (log)
     projects |> Seq.iter (runSingleProject)
@@ -145,7 +145,7 @@ Target "NBench" <| fun _ ->
             info.WorkingDirectory <- (Directory.GetParent project).FullName
             info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
         
-        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result
     
     projects |> Seq.iter runSingleProject
 

--- a/build.ps1
+++ b/build.ps1
@@ -30,9 +30,6 @@ Param(
 )
 
 $FakeVersion = "4.61.2"
-$DotNetChannel = "LTS";
-$DotNetVersion = "2.1.500";
-$DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "4.1.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"
 $ProtobufVersion = "3.4.0"

--- a/build.sh
+++ b/build.sh
@@ -11,9 +11,6 @@ NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe
 FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
-DOTNET_VERSION=2.1.500
-DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v$DOTNET_VERSION/scripts/obtain/dotnet-install.sh
-DOTNET_CHANNEL=LTS;
 DOCFX_VERSION=2.40.5
 DOCFX_EXE=$TOOLS_DIR/docfx.console/tools/docfx.exe
 
@@ -41,22 +38,6 @@ done
 if [ ! -d "$TOOLS_DIR" ]; then
   mkdir "$TOOLS_DIR"
 fi
-
-###########################################################################
-# INSTALL .NET CORE CLI
-###########################################################################
-
-echo "Installing .NET CLI..."
-if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
-  mkdir "$SCRIPT_DIR/.dotnet"
-fi
-curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
-export PATH="$SCRIPT_DIR/.dotnet":$PATH
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-chmod -R 0755 ".dotnet"
-"$SCRIPT_DIR/.dotnet/dotnet" --info
 
 
 ###########################################################################

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2020 Petabridge®</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.4.0</VersionPrefix>
-    <PackageReleaseNotes>Upgraded to [Akka.NET v1.4.1](https://getakka.net/community/whats-new/akkadotnet-v1.4.html)</PackageReleaseNotes>
+    <VersionPrefix>0.5.0</VersionPrefix>
+    <PackageReleaseNotes>Upgraded to [Akka.NET v1.4.14](https://github.com/akkadotnet/akka.net/releases/tag/1.4.14)
+[Print seed nodes when bootstrapping from environment variables as array](https://github.com/petabridge/akkadotnet-bootstrap/issues/104)</PackageReleaseNotes>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/petabridge/akkadotnet-bootstrap</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/petabridge/akkadotnet-bootstrap/blob/master/LICENSE</PackageLicenseUrl>
@@ -21,7 +22,7 @@
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.9.4</TestSdkVersion>
-    <NetCoreTestVersion>netcoreapp2.1</NetCoreTestVersion>
+    <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetStandardVersion>netstandard2.0</NetStandardVersion>
     <NetFrameworkTestVersion>net461</NetFrameworkTestVersion>
     <AkkaVersion>1.4.18</AkkaVersion>


### PR DESCRIPTION
- Moved to .NET Core 3.1
- Removed `dotnet-install` scripts
- Ensured that if unit tests fail, FAKE fails build status