### PR TITLE
Fix problem with complex values injected through env var will broke HOCON config parser

### DIFF
--- a/src/Akka.Bootstrap.Docker.Tests/DockerBootstrapSpecs.cs
+++ b/src/Akka.Bootstrap.Docker.Tests/DockerBootstrapSpecs.cs
@@ -105,7 +105,7 @@ namespace Akka.Bootstrap.Docker.Tests
             myConfig.GetInt("akka.remote.dot-netty.tcp.port").Should().Be(2559);
             myConfig.GetStringList("akka.cluster.roles").Should().BeEquivalentTo(new [] { "demo", "test", "backup" });
         }
-        
+		
         [Fact]
         public void ShouldNotAssignDefaultHostNameIfAssignDefaultHostNameParamIsFalse()
         {
@@ -119,6 +119,34 @@ namespace Akka.Bootstrap.Docker.Tests
             
             myConfig.GetString("akka.remote.dot-netty.tcp.hostname").Should().Be(hostname);
             myConfig.GetString("akka.remote.dot-netty.tcp.public-hostname").Should().Be(publicHostName);
+        }
+		
+        [Fact]
+        public void ShouldGenerateValidHoconConfigWithComplexEnvironmentValue()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("AKKA__CLUSTER__DOWNING_PROVIDER_CLASS", "Akka.Cluster.SplitBrainResolver, Akka.Cluster", EnvironmentVariableTarget.Process);
+                Environment.SetEnvironmentVariable("CLUSTER_SEEDS", "akka.tcp://MySys@localhost:9140, akka.tcp://MySys@localhost:9141", EnvironmentVariableTarget.Process);
+                Environment.SetEnvironmentVariable("AKKA__RANDOM__URL", "akka.tcp://MySys@localhost:9140", EnvironmentVariableTarget.Process);
+
+                var myConfig = ConfigurationFactory.Empty.BootstrapFromDocker();
+                myConfig.GetString("akka.cluster.downing-provider-class").Should().Be("Akka.Cluster.SplitBrainResolver, Akka.Cluster");
+                myConfig.GetString("akka.random.url").Should().Be("akka.tcp://MySys@localhost:9140");
+                var expected = new[]
+                {
+                    "akka.tcp://MySys@localhost:9140",
+                    "akka.tcp://MySys@localhost:9141"
+                };
+                myConfig.HasPath("akka.cluster.seed-nodes").Should().BeTrue();
+                myConfig.GetStringList("akka.cluster.seed-nodes").Should().BeEquivalentTo(expected);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AKKA__RANDOM__URL", null);
+                Environment.SetEnvironmentVariable("AKKA__CLUSTER__DOWNING_PROVIDER_CLASS", null);
+                Environment.SetEnvironmentVariable("CLUSTER_SEEDS", null);
+            }
         }
     }
 }

--- a/src/Akka.Bootstrap.Docker.Tests/DockerBootstrapSpecs.cs
+++ b/src/Akka.Bootstrap.Docker.Tests/DockerBootstrapSpecs.cs
@@ -105,5 +105,20 @@ namespace Akka.Bootstrap.Docker.Tests
             myConfig.GetInt("akka.remote.dot-netty.tcp.port").Should().Be(2559);
             myConfig.GetStringList("akka.cluster.roles").Should().BeEquivalentTo(new [] { "demo", "test", "backup" });
         }
+        
+        [Fact]
+        public void ShouldNotAssignDefaultHostNameIfAssignDefaultHostNameParamIsFalse()
+        {
+            var hostname = "127.0.0.1";
+            var publicHostName = "example.local";
+            
+            var myConfig = ConfigurationFactory.Empty
+                .WithFallback(ConfigurationFactory.ParseString($"akka.remote.dot-netty.tcp.hostname={hostname}"))
+                .WithFallback(ConfigurationFactory.ParseString($"akka.remote.dot-netty.tcp.public-hostname={publicHostName}"))
+                .BootstrapFromDocker(assignDefaultHostName: false);
+            
+            myConfig.GetString("akka.remote.dot-netty.tcp.hostname").Should().Be(hostname);
+            myConfig.GetString("akka.remote.dot-netty.tcp.public-hostname").Should().Be(publicHostName);
+        }
     }
 }

--- a/src/Akka.Bootstrap.Docker/DockerBootstrap.cs
+++ b/src/Akka.Bootstrap.Docker/DockerBootstrap.cs
@@ -37,21 +37,24 @@ namespace Akka.Bootstrap.Docker
         /// </example>
         public static Config BootstrapFromDocker(this Config input, bool assignDefaultHostName = true)
         {
-            var finalConfig =  ConfigurationFactory.Empty
-                .FromEnvironment()
-                .WithFallback(
-                    ConfigurationFactory.ParseString(
-                        $@"
+            var finalConfig =  ConfigurationFactory.Empty.FromEnvironment();
+            
+            if (assignDefaultHostName)
+            {
+                finalConfig = finalConfig
+                    .WithFallback(
+                        ConfigurationFactory.ParseString(
+                            $@"
                             akka.remote.dot-netty.tcp {{
                                 hostname=0.0.0.0
                                 public-hostname={Dns.GetHostName()}
                             }}
                         "
-                    )
-                )
-                .WithFallback(
-                    input
-                );
+                        )
+                    );
+            }
+
+            finalConfig = finalConfig.WithFallback(input);
 
             // Diagnostic logging
             Console.WriteLine($"[Docker-Bootstrap] IP={finalConfig.GetString("akka.remote.dot-netty.tcp.public-hostname")}");

--- a/src/Akka.Bootstrap.Docker/EnvironmentVariableConfigLoader.cs
+++ b/src/Akka.Bootstrap.Docker/EnvironmentVariableConfigLoader.cs
@@ -79,6 +79,11 @@ namespace Akka.Bootstrap.Docker
                         value = "[]";
                     }
                 }
+                else
+                {
+                    if (value.NeedQuotes() || value.NeedTripleQuotes())
+                        value = value.AddQuotes();
+                }
 
                 yield return EnvironmentVariableConfigEntrySource.Create(
                     key.ToLower().ToString(), 

--- a/src/Akka.Bootstrap.Docker/EnvironmentVariableConfigLoader.cs
+++ b/src/Akka.Bootstrap.Docker/EnvironmentVariableConfigLoader.cs
@@ -81,7 +81,9 @@ namespace Akka.Bootstrap.Docker
                 }
                 else
                 {
-                    if (value.NeedQuotes() || value.NeedTripleQuotes())
+                    if (value.NeedTripleQuotes())
+                        value = value.AddTripleQuotes();
+                    else if (value.NeedQuotes())
                         value = value.AddQuotes();
                 }
 

--- a/src/Akka.Bootstrap.Docker/StringExtension.cs
+++ b/src/Akka.Bootstrap.Docker/StringExtension.cs
@@ -8,7 +8,7 @@ namespace Akka.Bootstrap.Docker
     public static class StringExtension
     {
         public const string NotInUnquotedText = "$\"{}[]:=,#`^?!@*&\\";
-        public const char NewLine = '\u000A';
+        public const string NewLine = "\n\r";
 
         public static bool NeedQuotes(this string s)
         {
@@ -17,7 +17,7 @@ namespace Akka.Bootstrap.Docker
 
         public static bool NeedTripleQuotes(this string s)
         {
-            return s.NeedQuotes() && s.Contains(NewLine);
+            return s.NeedQuotes() && s.Any(c => NewLine.Contains(c));
         }
 
         public static string AddQuotes(this string s)
@@ -26,6 +26,11 @@ namespace Akka.Bootstrap.Docker
                 return "\"" + s.Replace("\"", "\\\"") + "\"";
 
             return "\"" + s + "\"";
+        }
+
+        public static string AddTripleQuotes(this string s)
+        {
+            return "\"\"" + s.AddQuotes() + "\"\"";
         }
     }
 }

--- a/src/Akka.Bootstrap.Docker/StringExtension.cs
+++ b/src/Akka.Bootstrap.Docker/StringExtension.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Akka.Bootstrap.Docker
+{
+    public static class StringExtension
+    {
+        public const string NotInUnquotedText = "$\"{}[]:=,#`^?!@*&\\";
+        public const char NewLine = '\u000A';
+
+        public static bool NeedQuotes(this string s)
+        {
+            return s.Any(c => NotInUnquotedText.Contains(c));
+        }
+
+        public static bool NeedTripleQuotes(this string s)
+        {
+            return s.NeedQuotes() && s.Contains(NewLine);
+        }
+
+        public static string AddQuotes(this string s)
+        {
+            if (s.Contains('"'))
+                return "\"" + s.Replace("\"", "\\\"") + "\"";
+
+            return "\"" + s + "\"";
+        }
+    }
+}


### PR DESCRIPTION
Any values that needs to be quoted in HOCON ( containing any character in the set [$"{}[]:=,#`^?!@*&\] and the new line character) will break the HOCON parser and generates an unchecked invalid HOCON config that can cause unpredictable errors in Akka.